### PR TITLE
Update usage of in_app_review

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -104,12 +104,8 @@ class _HomeState extends State<Home> {
               onTap: () async {
                 Navigator.pop(context);
                 final InAppReview inAppReview = InAppReview.instance;
-
-                if (await inAppReview.isAvailable()) {
-                  inAppReview.requestReview();
-                } else {
-                  inAppReview.openStoreListing();
-                }
+                
+                inAppReview.openStoreListing();
               },
             ),
           ],


### PR DESCRIPTION
`inAppReview.requestReview()` shouldn't be used in response to a button being pressed as the underlying API will likely do nothing the second time the button is pressed and no review prompt will appear as a result.

If `inAppReview.isAvailable()`returns true, it doesn't guarantee that a review prompt will appear when `inAppReview.requestReview()` is invoked unfortunately.

https://developer.android.com/guide/playcore/in-app-review#quotas